### PR TITLE
Remove sensitive sync-settings setting data

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -7,6 +7,7 @@ fs = require 'fs'
 
 # constants
 DESCRIPTION = 'Atom configuration store operated by http://atom.io/packages/sync-settings'
+REMOVE_KEYS = ["sync-settings"]
 
 module.exports =
   configDefaults:
@@ -25,7 +26,7 @@ module.exports =
   upload: (cb=null) ->
     files =
       "settings.json":
-        content: JSON.stringify(atom.config.settings, null, '\t')
+        content: JSON.stringify(atom.config.settings, @filterSettings, '\t')
       "packages.json":
         content: JSON.stringify(@getPackages(), null, '\t')
       "keymap.cson":
@@ -93,6 +94,11 @@ module.exports =
       type: 'oauth'
       token: token
     github
+
+  filterSettings: (key, value) ->
+    return value if key == ""
+    return undefined if ~REMOVE_KEYS.indexOf(key)
+    value
 
   applySettings: (pref, settings) ->
     for key, value of settings


### PR DESCRIPTION
Don't upload the `personalAccessToken` or `gistId`. The access token is as good as a password so even if someone has locked down the token to only update Gist, they could still make changes to other Gists of the user.

Fixes #14 