### PR TITLE
Added notifications feedbacks

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -45,7 +45,9 @@ module.exports =
     , (err, res) =>
       if err
           console.error "error uploading data: "+err.message, err
-          atom.notifications.addError "sync-settings: Error uploading data. ("+JSON.parse(err.message).message+")"
+          message = JSON.parse(err.message).message
+          message = 'Gist ID Not Found' if message == 'Not Found'
+          atom.notifications.addError "sync-settings: Error uploading your settings. ("+message+")"
       else
           atom.notifications.addSuccess "sync-settings: Your settings was successfully uploaded."
       cb?(err, res)
@@ -61,7 +63,9 @@ module.exports =
     , (err, res) =>
       if err
         console.error "error while retrieving the gist. does it exists?", err
-        atom.notifications.addError "sync-settings: Error while retrieving the gist. Does it exists? ("+JSON.parse(err.message).message+")"
+        message = JSON.parse(err.message).message
+        message = 'Gist ID Not Found' if message == 'Not Found'
+        atom.notifications.addError "sync-settings: Error retrieving your settings. ("+message+")"
         return
 
       settings = JSON.parse(res.files["settings.json"].content)
@@ -88,7 +92,7 @@ module.exports =
       console.debug "snippets.cson = ", snippetsCson
       fs.writeFileSync(atom.config.configDirPath + "/snippets.cson", snippetsCson) if snippetsCson
 
-      atom.notifications.addSuccess "sync-settings: Your settings was successfully synced from the Gist."
+      atom.notifications.addSuccess "sync-settings: Your settings was successfully synced."
 
   createClient: ->
     token = atom.config.get 'sync-settings.personalAccessToken'

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -49,7 +49,7 @@ module.exports =
           message = 'Gist ID Not Found' if message == 'Not Found'
           atom.notifications.addError "sync-settings: Error uploading your settings. ("+message+")"
       else
-          atom.notifications.addSuccess "sync-settings: Your settings was successfully uploaded."
+          atom.notifications.addSuccess "sync-settings: Your settings were successfully uploaded."
       cb?(err, res)
 
   getPackages: ->
@@ -92,7 +92,7 @@ module.exports =
       console.debug "snippets.cson = ", snippetsCson
       fs.writeFileSync(atom.config.configDirPath + "/snippets.cson", snippetsCson) if snippetsCson
 
-      atom.notifications.addSuccess "sync-settings: Your settings was successfully synced."
+      atom.notifications.addSuccess "sync-settings: Your settings were successfully synchronized."
 
   createClient: ->
     token = atom.config.get 'sync-settings.personalAccessToken'

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -43,7 +43,11 @@ module.exports =
       description: "automatic update by http://atom.io/packages/sync-settings"
       files: files
     , (err, res) =>
-      console.error "error uploading data: "+err.message, err if err
+      if err
+          console.error "error uploading data: "+err.message, err
+          atom.notifications.addError "sync-settings: Error uploading data. ("+JSON.parse(err.message).message+")"
+      else
+          atom.notifications.addSuccess "sync-settings: Your settings was successfully uploaded."
       cb?(err, res)
 
   getPackages: ->
@@ -56,7 +60,8 @@ module.exports =
       id: atom.config.get 'sync-settings.gistId'
     , (err, res) =>
       if err
-        console.error("error while retrieving the gist. does it exists?", err)
+        console.error "error while retrieving the gist. does it exists?", err
+        atom.notifications.addError "sync-settings: Error while retrieving the gist. Does it exists? ("+JSON.parse(err.message).message+")"
         return
 
       settings = JSON.parse(res.files["settings.json"].content)
@@ -82,6 +87,8 @@ module.exports =
       snippetsCson = res.files['snippets.cson']?.content
       console.debug "snippets.cson = ", snippetsCson
       fs.writeFileSync(atom.config.configDirPath + "/snippets.cson", snippetsCson) if snippetsCson
+
+      atom.notifications.addSuccess "sync-settings: Your settings was successfully synced from the Gist."
 
   createClient: ->
     token = atom.config.get 'sync-settings.personalAccessToken'


### PR DESCRIPTION
I loved this package so much, but besides autoupdate (which i understand is in the works), I really found it irritating not to get any notification on upload/download.

With this commit will both failed and successful attempts at syncing display an `atom.notification` message appropriate to the result.

*Successes*
![success](https://cloud.githubusercontent.com/assets/180510/5647534/17c279b2-9687-11e4-8d93-713fde4490a2.png)

*Bad credential (O-Auth)*
![bad-credentials](https://cloud.githubusercontent.com/assets/180510/5647538/1c2e44ae-9687-11e4-8196-9ccc48c932b3.png)

*Non-existent Gist*
![gist-id-not-found](https://cloud.githubusercontent.com/assets/180510/5647542/2008fb50-9687-11e4-9007-6e29be11bcbe.png)

Let me know if there is anything you'd want me to change around. Thanks so much for this amazing package!