### PR TITLE
Command scope-selector 'atom-text-editor' -> 'atom-workspace'

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -16,8 +16,8 @@ module.exports =
 
   activate: ->
     # for debug
-    atom.commands.add 'atom-text-editor', "sync-settings:upload", => @upload()
-    atom.commands.add 'atom-text-editor', "sync-settings:download", => @download()
+    atom.commands.add 'atom-workspace', "sync-settings:upload", => @upload()
+    atom.commands.add 'atom-workspace', "sync-settings:download", => @download()
 
   deactivate: ->
 


### PR DESCRIPTION
The `sync-settings:upload` and `sync-settings:download` commands only showed up in the command palette while inside a text editor, so not if in settings view or basically anything that isn't a text editor. With this change the commands always show up in the command palette