### PR TITLE
Changed keymap scope-selector

### DIFF
--- a/keymaps/sync-settings.cson
+++ b/keymaps/sync-settings.cson
@@ -7,6 +7,6 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.atom-workspace':
+'atom-workspace':
   'ctrl-alt-u': 'sync-settings:upload'
   'ctrl-alt-d': 'sync-settings:download'


### PR DESCRIPTION
The scope selector was `.atom-workspace` indicating a class, but `atom-workspace` is actually an element