### PR TITLE
moved away from deprecated 'configDefaults'

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -10,9 +10,15 @@ DESCRIPTION = 'Atom configuration store operated by http://atom.io/packages/sync
 REMOVE_KEYS = ["sync-settings"]
 
 module.exports =
-  configDefaults:
-    personalAccessToken: "<Your personal GitHub access token>"
-    gistId: "<Id of gist to use for configuration store>"
+  config:
+    personalAccessToken:
+      description: 'Your personal GitHub access token'
+      type: 'string'
+      default: ''
+    gistId:
+      description: 'Id of gist to use for configutation store'
+      type: 'string'
+      default: ''
 
   activate: ->
     # for debug


### PR DESCRIPTION
Converted the `configDefaults` object to a [config schema](https://atom.io/docs/api/v0.184.0/Config#config-schemas) because `configDefaults` is deprecated