### PR TITLE
Add setting to also upload files other than Atom's default files

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -50,7 +50,7 @@ module.exports =
       "snippets.cson":
         content: @fileContent atom.config.configDirPath + "/snippets.cson"
 
-    for file in atom.config.get 'sync-settings.extraFiles'
+    for file in atom.config.get('sync-settings.extraFiles') ? []
       files[file] =
         content: @fileContent atom.config.configDirPath + "/#{file}"
 
@@ -84,19 +84,19 @@ module.exports =
         atom.notifications.addError "sync-settings: Error retrieving your settings. ("+message+")"
         return
 
-      for own file, filename of res.files
+      for own filename, file of res.files
         switch filename
           when 'settings.json'
             @applySettings '', JSON.parse(file.content)
 
           when 'packages.json'
-            @installMissintPackages JSON.parse(file.content), cb
+            @installMissingPackages JSON.parse(file.content), cb
 
           when 'keymap.cson'
             fs.writeFileSync atom.keymap.getUserKeymapPath(), file.content
 
           when 'styles.less'
-            fs.writeFileSync atom.themes.getUserStyleSheetPath(), file.content
+            fs.writeFileSync atom.styles.getUserStyleSheetPath(), file.content
 
           when 'init.coffee'
             fs.writeFileSync atom.config.configDirPath + "/init.coffee", file.content
@@ -113,7 +113,7 @@ module.exports =
     console.debug "Creating GitHubApi client with token = #{token}"
     github = new GitHubApi
       version: '3.0.0'
-      debug: true
+      # debug: true
       protocol: 'https'
     github.authenticate
       type: 'oauth'

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -19,6 +19,12 @@ module.exports =
       description: 'Id of gist to use for configutation store'
       type: 'string'
       default: ''
+    extraFiles:
+      description: 'Comnma seperated list of files other than Atom\'s default config files in ~/.atom'
+      type: 'array'
+      default: []
+      items:
+        type: 'string'
 
   activate: ->
     # for debug
@@ -43,6 +49,10 @@ module.exports =
         content: @fileContent atom.config.configDirPath + "/init.coffee"
       "snippets.cson":
         content: @fileContent atom.config.configDirPath + "/snippets.cson"
+
+    for file in atom.config.get 'sync-settings.extraFiles'
+      files[file] =
+        content: @fileContent atom.config.configDirPath + "/#{file}"
 
     @createClient().gists.edit
       id: atom.config.get 'sync-settings.gistId'
@@ -74,29 +84,27 @@ module.exports =
         atom.notifications.addError "sync-settings: Error retrieving your settings. ("+message+")"
         return
 
-      settings = JSON.parse(res.files["settings.json"].content)
-      console.debug "settings: ", settings
-      @applySettings "", settings
+      for own file, filename of res.files
+        switch filename
+          when 'settings.json'
+            @applySettings '', JSON.parse(file.content)
 
-      packages = JSON.parse(res.files["packages.json"].content)
-      console.debug "packages: ", packages
-      @installMissingPackages packages, cb
+          when 'packages.json'
+            @installMissintPackages JSON.parse(file.content), cb
 
-      keymap = res.files['keymap.cson']?.content
-      console.debug "keymap.cson = ", res.files['keymap.cson']?.content
-      fs.writeFileSync(atom.keymap.getUserKeymapPath(), res.files['keymap.cson'].content) if keymap
+          when 'keymap.cson'
+            fs.writeFileSync atom.keymap.getUserKeymapPath(), file.content
 
-      styles = res.files['styles.less']?.content
-      console.debug "styles.less = ", res.files['styles.less']?.content
-      fs.writeFileSync(atom.themes.getUserStylesheetPath(), res.files['styles.less'].content) if styles
+          when 'styles.less'
+            fs.writeFileSync atom.themes.getUserStyleSheetPath(), file.content
 
-      initCoffee = res.files['init.coffee']?.content
-      console.debug "init.coffee = ", initCoffee
-      fs.writeFileSync(atom.config.configDirPath + "/init.coffee", initCoffee) if initCoffee
+          when 'init.coffee'
+            fs.writeFileSync atom.config.configDirPath + "/init.coffee", file.content
 
-      snippetsCson = res.files['snippets.cson']?.content
-      console.debug "snippets.cson = ", snippetsCson
-      fs.writeFileSync(atom.config.configDirPath + "/snippets.cson", snippetsCson) if snippetsCson
+          when 'snippets.cson'
+            fs.writeFileSync atom.config.configDirPath + "/snippets.coffee", file.content
+
+          else fs.writeFileSync "#{atom.config.configDirPath}/#{filename}"
 
       atom.notifications.addSuccess "sync-settings: Your settings were successfully synchronized."
 

--- a/spec/sync-settings-spec.coffee
+++ b/spec/sync-settings-spec.coffee
@@ -125,7 +125,7 @@ describe "SyncSettings", ->
             expect(SyncSettings.fileContent(atom.keymap.getUserKeymapPath())).toEqual original
             fs.writeFileSync atom.keymap.getUserKeymapPath(), original
 
-      it "downloads the files defined in config.extraFiles", ->
+      it "downloads all other files in the gist as well", ->
         atom.config.set 'sync-settings.extraFiles', ['test.tmp', 'test2.tmp']
         run (cb) ->
           SyncSettings.upload cb

--- a/spec/sync-settings-spec.coffee
+++ b/spec/sync-settings-spec.coffee
@@ -66,7 +66,6 @@ describe "SyncSettings", ->
       it "uploads the settings", ->
         run (cb) ->
           SyncSettings.upload cb
-
         , ->
           run (cb) =>
             SyncSettings.createClient().gists.get({id: @gistId}, cb)
@@ -76,7 +75,6 @@ describe "SyncSettings", ->
       it "uploads the installed packages list", ->
         run (cb) ->
           SyncSettings.upload cb
-
         , ->
           run (cb) =>
             SyncSettings.createClient().gists.get({id: @gistId}, cb)
@@ -137,4 +135,4 @@ describe "SyncSettings", ->
           , ->
             for file in atom.config.get 'sync-settings.extraFiles'
               expect(fs.existsSync("#{atom.config.configDirPath}/#{file}")).toBe(true)
-              # fs.unlink "#{atom.config.configDirPath}/#{file}"
+              fs.unlink "#{atom.config.configDirPath}/#{file}"

--- a/spec/sync-settings-spec.coffee
+++ b/spec/sync-settings-spec.coffee
@@ -92,6 +92,17 @@ describe "SyncSettings", ->
           , (err, res) ->
             expect(res.files['keymap.cson']).toBeDefined()
 
+      it "uploads the files defined in config.extraFiles", ->
+        atom.config.set 'sync-settings.extraFiles', ['test.tmp', 'test2.tmp']
+        run (cb) ->
+          SyncSettings.upload cb
+        , ->
+          run (cb) =>
+            SyncSettings.createClient().gists.get({id: @gistId}, cb)
+          , (err, res) ->
+            for file in atom.config.get 'sync-settings.extraFiles'
+              expect(res.files[file]).toBeDefined()
+
     describe "::download", ->
       it "updates settings", ->
         atom.config.set "some-dummy", true
@@ -115,3 +126,15 @@ describe "SyncSettings", ->
           , ->
             expect(SyncSettings.fileContent(atom.keymap.getUserKeymapPath())).toEqual original
             fs.writeFileSync atom.keymap.getUserKeymapPath(), original
+
+      it "downloads the files defined in config.extraFiles", ->
+        atom.config.set 'sync-settings.extraFiles', ['test.tmp', 'test2.tmp']
+        run (cb) ->
+          SyncSettings.upload cb
+        , ->
+          run (cb) =>
+            SyncSettings.download cb
+          , ->
+            for file in atom.config.get 'sync-settings.extraFiles'
+              expect(fs.existsSync("#{atom.config.configDirPath}/#{file}")).toBe(true)
+              # fs.unlink "#{atom.config.configDirPath}/#{file}"


### PR DESCRIPTION
Add a setting, `extraFiles`, that defines files inside the `~/.atom` directory other than Atom's default config files that should also be uploaded.

Also implements #31 