### PR TITLE
Default config file contents could be confusing

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -42,17 +42,17 @@ module.exports =
       "packages.json":
         content: JSON.stringify(@getPackages(), null, '\t')
       "keymap.cson":
-        content: @fileContent atom.keymap.getUserKeymapPath()
+        content: (@fileContent atom.keymap.getUserKeymapPath()) ? "# keymap file (not found)"
       "styles.less":
-        content: @fileContent atom.styles.getUserStyleSheetPath()
+        content: (@fileContent atom.styles.getUserStyleSheetPath()) ? "// styles file (not found)"
       "init.coffee":
-        content: @fileContent atom.config.configDirPath + "/init.coffee"
+        content: (@fileContent atom.config.configDirPath + "/init.coffee") ? "# initialization file (not found)"
       "snippets.cson":
-        content: @fileContent atom.config.configDirPath + "/snippets.cson"
+        content: (@fileContent atom.config.configDirPath + "/snippets.cson") ? "# snippets file (not found)"
 
     for file in atom.config.get('sync-settings.extraFiles') ? []
       files[file] =
-        content: @fileContent atom.config.configDirPath + "/#{file}"
+        content: @fileContent atom.config.configDirPath + "/#{file}" ? "# user specified settings (not found)"
 
     @createClient().gists.edit
       id: atom.config.get 'sync-settings.gistId'
@@ -156,9 +156,8 @@ module.exports =
       cb?(error)
 
   fileContent: (filePath) ->
-    DEFAULT_CONTENT = '# keymap file'
     try
-      return fs.readFileSync(filePath, {encoding: 'utf8'}) || DEFAULT_CONTENT
+      return fs.readFileSync(filePath, {encoding: 'utf8'}) || null
     catch e
       console.error "Error reading file #{filePath}. Probably doesn't exists.", e
-      DEFAULT_CONTENT
+      null

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -52,7 +52,7 @@ module.exports =
 
     for file in atom.config.get('sync-settings.extraFiles') ? []
       files[file] =
-        content: @fileContent atom.config.configDirPath + "/#{file}" ? "# user specified settings (not found)"
+        content: (@fileContent atom.config.configDirPath + "/#{file}") ? "# user specified settings (not found)"
 
     @createClient().gists.edit
       id: atom.config.get 'sync-settings.gistId'

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -51,8 +51,14 @@ module.exports =
         content: (@fileContent atom.config.configDirPath + "/snippets.cson") ? "# snippets file (not found)"
 
     for file in atom.config.get('sync-settings.extraFiles') ? []
+      ext = file.slice(file.lastIndexOf(".")).toLowerCase()
+      cmtstart = "#"
+      cmtstart = "//" if ext in [".less", ".scss", ".js"]
+      cmtstart = "/*" if ext in [".css"]
+      cmtend = ""
+      cmtend = "*/" if ext in [".css"]
       files[file] =
-        content: (@fileContent atom.config.configDirPath + "/#{file}") ? "# user specified settings (not found)"
+        content: (@fileContent atom.config.configDirPath + "/#{file}") ? "#{cmtstart} extra (not found) #{cmtend}"
 
     @createClient().gists.edit
       id: atom.config.get 'sync-settings.gistId'

--- a/menus/sync-settings.cson
+++ b/menus/sync-settings.cson
@@ -3,7 +3,7 @@
   {
     'label': 'Packages'
     'submenu': [
-      'label': 'Syncronize Settings'
+      'label': 'Synchronize Settings'
       'submenu': [
         { 'label': 'Upload', 'command': 'sync-settings:upload' }
         { 'label': 'Download', 'command': 'sync-settings:download' }


### PR DESCRIPTION
Hello,

as many already did, I found this package very useful: Atom is the tool I was waiting for, and installed it on many workstations, and the ability to synchronize packages was very attractive. However, when I first installed it, I thought it was not working, just because it wrote the string "# keymap file" in many places. At first, I uninstalled it. Then I started lurking, and didn't see anyone complaining about malfunctioning or swapped files, so I opened the dev tools in Atom and noticed that it was just the same string being issued as a default for all files that generated errors or simply weren't found. So I tried to modify the library code in order to change the default contents, depending on the file name. I saw that it worked and decided to propose to you to evaluate the possibility to include such a feature in the master branch.

It hasn't got to be my code: it's my first attempt at coffeescript, and it might be broken or just ugly. However some users could be less confused when they examine the Gist after an upload if the default file contents are differentiated.

Thank you for your work,

F.