### PR TITLE
Solve issue #36 (Snippets not applied)

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -108,7 +108,7 @@ module.exports =
             fs.writeFileSync atom.config.configDirPath + "/init.coffee", file.content
 
           when 'snippets.cson'
-            fs.writeFileSync atom.config.configDirPath + "/snippets.coffee", file.content
+            fs.writeFileSync atom.config.configDirPath + "/snippets.cson", file.content
 
           else fs.writeFileSync "#{atom.config.configDirPath}/#{filename}"
 

--- a/spec/sync-settings-spec.coffee
+++ b/spec/sync-settings-spec.coffee
@@ -90,6 +90,15 @@ describe "SyncSettings", ->
           , (err, res) ->
             expect(res.files['keymap.cson']).toBeDefined()
 
+      it "uploads the user snippets.cson file", ->
+        run (cb) ->
+          SyncSettings.upload cb
+        , ->
+          run (cb) =>
+            SyncSettings.createClient().gists.get({id: @gistId}, cb)
+          , (err, res) ->
+            expect(res.files['snippets.cson']).toBeDefined()
+
       it "uploads the files defined in config.extraFiles", ->
         atom.config.set 'sync-settings.extraFiles', ['test.tmp', 'test2.tmp']
         run (cb) ->


### PR DESCRIPTION
Changes the name of the downloaded gist file to `snippets.cson`.

F.