### PR TITLE
:art: extract package configuration to separate file

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -1,0 +1,43 @@
+module.exports = {
+  personalAccessToken:
+    description: 'Your personal GitHub access token'
+    type: 'string'
+    default: ''
+    order: 1
+  gistId:
+    description: 'ID of gist to use for configuration storage'
+    type: 'string'
+    default: ''
+    order: 2
+  syncSettings:
+    type: 'boolean'
+    default: true
+    order: 3
+  syncPackages:
+    type: 'boolean'
+    default: true
+    order: 4
+  syncKeymap:
+    type: 'boolean'
+    default: true
+    order: 5
+  syncStyles:
+    type: 'boolean'
+    default: true
+    order: 6
+  syncInit:
+    type: 'boolean'
+    default: true
+    order: 7
+  syncSnippets:
+    type: 'boolean'
+    default: true
+    order: 8
+  extraFiles:
+    description: 'Comma-seperated list of files other than Atom\'s default config files in ~/.atom'
+    type: 'array'
+    default: []
+    items:
+      type: 'string'
+    order: 9
+}

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -11,48 +11,7 @@ DESCRIPTION = 'Atom configuration storage operated by http://atom.io/packages/sy
 REMOVE_KEYS = ["sync-settings"]
 
 module.exports =
-  config:
-    personalAccessToken:
-      description: 'Your personal GitHub access token'
-      type: 'string'
-      default: ''
-      order: 1
-    gistId:
-      description: 'ID of gist to use for configuration storage'
-      type: 'string'
-      default: ''
-      order: 2
-    syncSettings:
-      type: 'boolean'
-      default: true
-      order: 3
-    syncPackages:
-      type: 'boolean'
-      default: true
-      order: 4
-    syncKeymap:
-      type: 'boolean'
-      default: true
-      order: 5
-    syncStyles:
-      type: 'boolean'
-      default: true
-      order: 6
-    syncInit:
-      type: 'boolean'
-      default: true
-      order: 7
-    syncSnippets:
-      type: 'boolean'
-      default: true
-      order: 8
-    extraFiles:
-      description: 'Comma-seperated list of files other than Atom\'s default config files in ~/.atom'
-      type: 'array'
-      default: []
-      items:
-        type: 'string'
-      order: 9
+  config: require('./config.coffee')
 
   activate: ->
     GitHubApi ?= require 'github'


### PR DESCRIPTION
Having the config file in separate file allows for clearer separation of concerns and possible reuse.