### PR TITLE
new menu option to open the gist with external browser

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -59,6 +59,7 @@ module.exports =
     PackageManager ?= require './package-manager'
     atom.commands.add 'atom-workspace', "sync-settings:backup", => @backup()
     atom.commands.add 'atom-workspace', "sync-settings:restore", => @restore()
+    atom.commands.add 'atom-workspace', "sync-settings:view-backup", => @viewBackup()
 
   deactivate: ->
 
@@ -102,6 +103,11 @@ module.exports =
       else
         atom.notifications.addSuccess "sync-settings: Your settings were successfully backed up. <br/><a href='"+res.html_url+"'>Click here to open your Gist.</a>"
       cb?(err, res)
+
+  viewBackup: ->
+    Shell = require 'shell'
+    gistId = atom.config.get 'sync-settings.gistId'
+    Shell.openExternal "https://gist.github.com/#{gistId}"
 
   getPackages: ->
     for own name, info of atom.packages.getLoadedPackages()

--- a/menus/sync-settings.cson
+++ b/menus/sync-settings.cson
@@ -7,6 +7,7 @@
       'submenu': [
         { 'label': 'Backup', 'command': 'sync-settings:backup' }
         { 'label': 'Restore', 'command': 'sync-settings:restore' }
+        { 'label': 'View backup', 'command': 'sync-settings:view-backup' }
       ]
     ]
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "activationCommands": {
     "atom-workspace": [
       "sync-settings:backup",
-      "sync-settings:restore"
+      "sync-settings:restore",
+      "sync-settings:view-backup"
     ]
   }
 }


### PR DESCRIPTION
Currently we allow the user to open the backup gist only for a short period of time after performing backup. This PR adds a new menu option that can open the gist at any time.