### PR TITLE
display notification if backup is newer than last one created/used

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Backup or restore all settings from the <kbd>Packages</kbd> menu or use one of t
 View your online backup using the following command:
 * `sync-settings:view-backup`
 
+Check the latest backup is applied:
+* `sync-settings:check-backup`
+
 ## Contributing
 
 If you're going to submit a pull request, please try to follow

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -40,4 +40,8 @@ module.exports = {
     items:
       type: 'string'
     order: 9
+  _lastBackupHash:
+    type: 'string'
+    default: ''
+    description: 'Hash of the last backup restores or created'
 }

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -40,6 +40,10 @@ module.exports = {
     items:
       type: 'string'
     order: 9
+  checkForUpdatedBackup:
+    description: 'Check for newer backup on Atom start'
+    type: 'boolean'
+    default: true
   _lastBackupHash:
     type: 'string'
     default: ''

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -47,5 +47,5 @@ module.exports = {
   _lastBackupHash:
     type: 'string'
     default: ''
-    description: 'Hash of the last backup restores or created'
+    description: 'Hash of the last backup restored or created'
 }

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -26,6 +26,7 @@ SyncSettings =
       atom.commands.add 'atom-workspace', "sync-settings:backup", => @backup()
       atom.commands.add 'atom-workspace', "sync-settings:restore", => @restore()
       atom.commands.add 'atom-workspace', "sync-settings:view-backup", => @viewBackup()
+      atom.commands.add 'atom-workspace', "sync-settings:check-backup", => @checkForUpdate()
 
       @checkForUpdate()
 

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -14,12 +14,16 @@ module.exports =
   config: require('./config.coffee')
 
   activate: ->
-    GitHubApi ?= require 'github'
-    PackageManager ?= require './package-manager'
-    atom.commands.add 'atom-workspace', "sync-settings:backup", => @backup()
-    atom.commands.add 'atom-workspace', "sync-settings:restore", => @restore()
-    atom.commands.add 'atom-workspace', "sync-settings:view-backup", => @viewBackup()
-    @checkForUpdate()
+    # speedup activation by async initializing
+    # further optimization can be achieved by minimizing this file
+    setImmediate =>
+      # actual initialization after atom has loaded
+      GitHubApi ?= require 'github'
+      PackageManager ?= require './package-manager'
+      atom.commands.add 'atom-workspace', "sync-settings:backup", => @backup()
+      atom.commands.add 'atom-workspace', "sync-settings:restore", => @restore()
+      atom.commands.add 'atom-workspace', "sync-settings:view-backup", => @viewBackup()
+      @checkForUpdate()
 
   deactivate: ->
 

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -61,32 +61,32 @@ SyncSettings =
       @notifyMissingGistId()
 
   notifyNewerBackup: ->
-    notification = atom.notifications.addInfo "sync-settings: Your settings are out of date.",
+    notification = atom.notifications.addWarning "sync-settings: Your settings are out of date.",
       dismissable: true
       buttons: [{
         text: "Backup"
-        className: 'btn-warning'
         onDidClick: ->
           SyncSettings.backup()
           notification.dismiss()
       }, {
         text: "View backup"
-        className: 'btn-info'
         onDidClick: ->
           SyncSettings.viewBackup()
       }, {
         text: "Restore"
-        className: 'btn-success'
         onDidClick: ->
           SyncSettings.restore()
           notification.dismiss()
+      }, {
+        text: "Dismiss"
+        onDidClick: -> notification.dismiss()
       }]
 
   notifyBackupUptodate: ->
     atom.notifications.addSuccess "sync-settings: Latest backup is already applied."
 
   notifyMissingGistId: ->
-    atom.notifications.addInfo "sync-settings: Missing gist ID"
+    atom.notifications.addError "sync-settings: Missing gist ID"
 
   backup: (cb=null) ->
     files = {}

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -66,16 +66,16 @@ SyncSettings =
       buttons: [{
         text: "Backup"
         onDidClick: ->
-          SyncSettings.backup()
+          atom.commands.dispatch 'atom-workspace', "sync-settings:backup"
           notification.dismiss()
       }, {
         text: "View backup"
         onDidClick: ->
-          SyncSettings.viewBackup()
+          atom.commands.dispatch 'atom-workspace', "sync-settings:view-backup"
       }, {
         text: "Restore"
         onDidClick: ->
-          SyncSettings.restore()
+          atom.commands.dispatch 'atom-workspace', "sync-settings:restore"
           notification.dismiss()
       }, {
         text: "Dismiss"

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -58,22 +58,26 @@ SyncSettings =
     else
       @notifyMissingGistId()
 
+
+
   notifyNewerBackup: ->
+    # we need the actual element for dispatching on it
+    workspaceElement = atom.views.getView(atom.workspace)
     notification = atom.notifications.addWarning "sync-settings: Your settings are out of date.",
       dismissable: true
       buttons: [{
         text: "Backup"
         onDidClick: ->
-          atom.commands.dispatch 'atom-workspace', "sync-settings:backup"
+          atom.commands.dispatch workspaceElement, "sync-settings:backup"
           notification.dismiss()
       }, {
         text: "View backup"
         onDidClick: ->
-          atom.commands.dispatch 'atom-workspace', "sync-settings:view-backup"
+          atom.commands.dispatch workspaceElement, "sync-settings:view-backup"
       }, {
         text: "Restore"
         onDidClick: ->
-          atom.commands.dispatch 'atom-workspace', "sync-settings:restore"
+          atom.commands.dispatch workspaceElement, "sync-settings:restore"
           notification.dismiss()
       }, {
         text: "Dismiss"

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -26,7 +26,7 @@ module.exports =
   serialize: ->
 
   checkForUpdate: (cb=null) ->
-    if atom.config.get('sync-settings.gistId')
+    if atom.config.get('sync-settings.gistId') and atom.config.get('sync-settings.checkForUpdatedBackup')
       setTimeout =>
         console.debug('checking latest backup...')
         @createClient().gists.get

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -53,6 +53,8 @@ SyncSettings =
         console.debug("latest backup version #{res.history[0].version}")
         if res.history[0].version isnt atom.config.get('sync-settings._lastBackupHash')
           @notifyNewerBackup()
+        else
+          @notifyBackupUptodate()
 
         cb?()
     else
@@ -79,6 +81,9 @@ SyncSettings =
           SyncSettings.restore()
           notification.dismiss()
       }]
+
+  notifyBackupUptodate: ->
+    atom.notifications.addSuccess "sync-settings: Latest backup is already applied."
 
   notifyMissingGistId: ->
     atom.notifications.addInfo "sync-settings: Missing gist ID"

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -7,8 +7,6 @@ _ = require 'underscore-plus'
 [GitHubApi, PackageManager] = []
 
 # constants
-syncUri = 'sync-settings:/'
-
 DESCRIPTION = 'Atom configuration storage operated by http://atom.io/packages/sync-settings'
 REMOVE_KEYS = ["sync-settings"]
 

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -17,7 +17,6 @@ SyncSettings =
 
   activate: ->
     # speedup activation by async initializing
-    # further optimization can be achieved by minimizing this file
     setImmediate =>
       # actual initialization after atom has loaded
       GitHubApi ?= require 'github'
@@ -82,7 +81,6 @@ SyncSettings =
       }]
 
   notifyMissingGistId: ->
-    # TODO: add link to open package settings if possible
     atom.notifications.addInfo "sync-settings: Missing gist ID"
 
   backup: (cb=null) ->
@@ -183,7 +181,7 @@ SyncSettings =
     console.debug "Creating GitHubApi client with token = #{token}"
     github = new GitHubApi
       version: '3.0.0'
-      debug: atom.inSpecMode()
+      # debug: true
       protocol: 'https'
     github.authenticate
       type: 'oauth'

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -28,35 +28,34 @@ SyncSettings =
       atom.commands.add 'atom-workspace', "sync-settings:view-backup", => @viewBackup()
       atom.commands.add 'atom-workspace', "sync-settings:check-backup", => @checkForUpdate()
 
-      @checkForUpdate()
+      @checkForUpdate() if atom.config.get('sync-settings.checkForUpdatedBackup')
 
   deactivate: ->
 
   serialize: ->
 
   checkForUpdate: (cb=null) ->
-    if atom.config.get('sync-settings.gistId') and atom.config.get('sync-settings.checkForUpdatedBackup')
-      setImmediate =>
-        console.debug('checking latest backup...')
-        @createClient().gists.get
-          id: atom.config.get 'sync-settings.gistId'
-        , (err, res) =>
-          console.debug(err, res)
-          if err
-            console.error "error while retrieving the gist. does it exists?", err
-            try
-              message = JSON.parse(err.message).message
-              message = 'Gist ID Not Found' if message is 'Not Found'
-            catch SyntaxError
-              message = err.message
-            atom.notifications.addError "sync-settings: Error retrieving your settings. ("+message+")"
-            return cb?()
+    if atom.config.get('sync-settings.gistId')
+      console.debug('checking latest backup...')
+      @createClient().gists.get
+        id: atom.config.get 'sync-settings.gistId'
+      , (err, res) =>
+        console.debug(err, res)
+        if err
+          console.error "error while retrieving the gist. does it exists?", err
+          try
+            message = JSON.parse(err.message).message
+            message = 'Gist ID Not Found' if message is 'Not Found'
+          catch SyntaxError
+            message = err.message
+          atom.notifications.addError "sync-settings: Error retrieving your settings. ("+message+")"
+          return cb?()
 
-          console.debug("latest backup version #{res.history[0].version}")
-          if res.history[0].version isnt atom.config.get('sync-settings._lastBackupHash')
-            @notifyNewerBackup()
+        console.debug("latest backup version #{res.history[0].version}")
+        if res.history[0].version isnt atom.config.get('sync-settings._lastBackupHash')
+          @notifyNewerBackup()
 
-          cb?()
+        cb?()
     else
       @notifyMissingGistId()
 

--- a/menus/sync-settings.cson
+++ b/menus/sync-settings.cson
@@ -8,6 +8,7 @@
         { 'label': 'Backup', 'command': 'sync-settings:backup' }
         { 'label': 'Restore', 'command': 'sync-settings:restore' }
         { 'label': 'View backup', 'command': 'sync-settings:view-backup' }
+        { 'label': 'Check for updated backup', 'command': 'sync-settings:check-backup' }
       ]
     ]
   }

--- a/package.json
+++ b/package.json
@@ -26,12 +26,5 @@
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"
-  },
-  "activationCommands": {
-    "atom-workspace": [
-      "sync-settings:backup",
-      "sync-settings:restore",
-      "sync-settings:view-backup"
-    ]
   }
 }

--- a/spec/sync-settings-spec.coffee
+++ b/spec/sync-settings-spec.coffee
@@ -278,6 +278,7 @@ describe "SyncSettings", ->
             SyncSettings.checkForUpdate cb
           , ->
             expect(atom.notifications.getNotifications().length).toBe(1)
+            expect(atom.notifications.getNotifications()[0].getType()).toBe('warning')
 
         it "ignores on up-to-date backup", ->
           run (cb) ->
@@ -287,4 +288,5 @@ describe "SyncSettings", ->
               atom.notifications.clear()
               SyncSettings.checkForUpdate cb
             , ->
-              expect(atom.notifications.getNotifications().length).toBe(0)
+              expect(atom.notifications.getNotifications().length).toBe(1)
+              expect(atom.notifications.getNotifications()[0].getType()).toBe('success')

--- a/spec/sync-settings-spec.coffee
+++ b/spec/sync-settings-spec.coffee
@@ -49,6 +49,7 @@ describe "SyncSettings", ->
         expect(err).toBeNull()
 
         @gistId = res.id
+        console.log "Using Gist #{@gistId}"
         atom.config.set(GIST_ID_CONFIG, @gistId)
 
     afterEach ->
@@ -248,3 +249,43 @@ describe "SyncSettings", ->
               expect(fs.existsSync("#{atom.config.configDirPath}/#{file}")).toBe(true)
               expect(SyncSettings.fileContent("#{atom.config.configDirPath}/#{file}")).toBe("# #{file} (not found) ")
               fs.unlink "#{atom.config.configDirPath}/#{file}"
+
+    describe "::check for update", ->
+
+      beforeEach ->
+        atom.config.unset 'sync-settings._lastBackupHash'
+
+      it "updates last hash on backup", ->
+        run (cb) ->
+          SyncSettings.backup cb
+        , ->
+          expect(atom.config.get "sync-settings._lastBackupHash").toBeDefined()
+
+      it "updates last hash on restore", ->
+        run (cb) ->
+          SyncSettings.restore cb
+        , ->
+          expect(atom.config.get "sync-settings._lastBackupHash").toBeDefined()
+
+      describe "::notification", ->
+        beforeEach ->
+          atom.notifications.clear()
+          window.resetTimeouts()
+
+        it "displays on newer backup", ->
+          run (cb) ->
+            SyncSettings.checkForUpdate cb
+            window.advanceClock()
+          , ->
+            expect(atom.notifications.getNotifications().length).toBe(1)
+
+        it "ignores on up-to-date backup", ->
+          run (cb) ->
+            SyncSettings.backup cb
+          , ->
+            run (cb) ->
+              atom.notifications.clear()
+              SyncSettings.checkForUpdate cb
+              window.advanceClock()
+            , ->
+              expect(atom.notifications.getNotifications().length).toBe(0)

--- a/spec/sync-settings-spec.coffee
+++ b/spec/sync-settings-spec.coffee
@@ -33,7 +33,9 @@ describe "SyncSettings", ->
     TOKEN_CONFIG = 'sync-settings.personalAccessToken'
     GIST_ID_CONFIG = 'sync-settings.gistId'
 
+    window.resetTimeouts()
     SyncSettings.activate()
+    window.advanceClock()
 
     beforeEach ->
       @token = process.env.GITHUB_TOKEN or atom.config.get(TOKEN_CONFIG)
@@ -270,12 +272,10 @@ describe "SyncSettings", ->
       describe "::notification", ->
         beforeEach ->
           atom.notifications.clear()
-          window.resetTimeouts()
 
         it "displays on newer backup", ->
           run (cb) ->
             SyncSettings.checkForUpdate cb
-            window.advanceClock()
           , ->
             expect(atom.notifications.getNotifications().length).toBe(1)
 
@@ -286,6 +286,5 @@ describe "SyncSettings", ->
             run (cb) ->
               atom.notifications.clear()
               SyncSettings.checkForUpdate cb
-              window.advanceClock()
             , ->
               expect(atom.notifications.getNotifications().length).toBe(0)


### PR DESCRIPTION
- [x] Check for update on startup
- [x] Config to turn on/off
- [x] Speed-up boot time
- [x] Add easy restore link/button
- [x] Menu to manually check for updated backup

The check is at atom start-up. Right now this adds about 500ms to startup time. With some refactoring I think it can go down to <100ms.

Dropped features from this PR:
- [ ] Check periodically


Ref #81 