### PR TITLE
Allow user to fork existing gist

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -9,37 +9,42 @@ module.exports = {
     type: 'string'
     default: ''
     order: 2
+  forkId:
+    description: 'ID of an existing gist to fork for configuration storage'
+    type: 'string'
+    default: ''
+    order: 3
   syncSettings:
     type: 'boolean'
     default: true
-    order: 3
+    order: 4
   syncPackages:
     type: 'boolean'
     default: true
-    order: 4
+    order: 5
   syncKeymap:
     type: 'boolean'
     default: true
-    order: 5
+    order: 6
   syncStyles:
     type: 'boolean'
     default: true
-    order: 6
+    order: 7
   syncInit:
     type: 'boolean'
     default: true
-    order: 7
+    order: 8
   syncSnippets:
     type: 'boolean'
     default: true
-    order: 8
+    order: 9
   extraFiles:
     description: 'Comma-seperated list of files other than Atom\'s default config files in ~/.atom'
     type: 'array'
     default: []
     items:
       type: 'string'
-    order: 9
+    order: 10
   analytics:
     type: 'boolean'
     default: true
@@ -47,20 +52,20 @@ module.exports = {
             Analytics to track what versions and platforms
             are used. Everything is anonymized and no personal information, such as source code,
             is sent. See the README.md for more details."
-    order: 10
+    order: 11
   _analyticsUserId:
     type: 'string'
     default: ""
     description: "Unique identifier for this user for tracking usage analytics"
-    order: 11
+    order: 12
   checkForUpdatedBackup:
     description: 'Check for newer backup on Atom start'
     type: 'boolean'
     default: true
-    order: 12
+    order: 13
   _lastBackupHash:
     type: 'string'
     default: ''
     description: 'Hash of the last backup restored or created'
-    order: 13
+    order: 14
 }

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -31,6 +31,9 @@ SyncSettings =
       atom.commands.add 'atom-workspace', "sync-settings:check-backup", =>
         @checkForUpdate()
         @tracker.track 'Check backup'
+      atom.commands.add 'atom-workspace', "sync-settings:fork", =>
+        @forkExisting()
+        @tracker.track 'Fork'
 
       @checkForUpdate() if atom.config.get('sync-settings.checkForUpdatedBackup')
 
@@ -248,5 +251,33 @@ SyncSettings =
     catch e
       console.error "Error reading file #{filePath}. Probably doesn't exist.", e
       null
+
+  forkExisting: (gistId) ->
+    if atom.config.get("sync-settings.forkId")
+      forkId = atom.config.get "sync-settings.forkId"
+      console.debug("forking existing settings...")
+      @createClient().gists.fork
+        id: forkId
+      , (err, res) =>
+        console.debug(err, res)
+        if err
+          console.error "error while retrieving the gist. does it exists?", err
+          try
+            message = JSON.parse(err.message).message
+            message = "Gist ID Not Found" if message is "Not Found"
+          catch SyntaxError
+            message = err.message
+          atom.notifications.addError "sync-settings: Error forking settings. ("+message+")"
+          return cb?()
+
+        console.debug("gist #{forkId} forked to #{res.id}")
+        if res.id
+          atom.config.set "sync-settings.gistId", res.id
+        else
+          atom.notifications.addError "sync-settings: Error forking settings"
+
+        cb?()
+    else
+      @notifyMissingForkId()
 
 module.exports = SyncSettings


### PR DESCRIPTION
The use case is as follows:

As a senior developer and instructor I often want to get new team members up to speed quickly. This means that they base their config on an existing company standard.

Right now, we've used sync settings as normal but added the extra step of having the new team members go to GH manually fork the team gist, then pull in their id and run restore.

While this isn't the end of the world, it is pretty far from ideal especially in the classroom setting where new devs might not be used to the concept of forks.

Instead this implements a new setting for `forkId` and adds a `sync-settings: Fork` command that accomplishes the following:

* Forks the specified gist from the `forkId` config
* If the fork creation was successful (returned both in the instance of a new fork or existing one), then set the gistId to the new id returned from the github fork API.

From there the user could run `Restore` as usual to get the settings on their local machine.

---

It's been a while since I've written in coffeescript and I tried to follow the standard style guides presented in the rest of the code.

I'm also wanting to wrap this in some tests, but running the test suite seems to be undocumented beyond `apm test` which was giving me almost all failure even on the existing master branch.