### PR TITLE
use deterministic order of packages

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -148,9 +148,11 @@ SyncSettings =
     Shell.openExternal "https://gist.github.com/#{gistId}"
 
   getPackages: ->
+    packages = []
     for own name, info of atom.packages.getLoadedPackages()
       {name, version, theme} = info.metadata
-      {name, version, theme}
+      packages.push({name, version, theme})
+    _.sortBy(packages, 'name')
 
   restore: (cb=null) ->
     @createClient().gists.get


### PR DESCRIPTION
Currently the backup file `packages.json` contains all packages in "random" order. So even if no package has changed the backup file likely has changes due to shuffling around the entries.

In order to avoid unnecessary changes and make the diff of the backup file more readable this patch orders the list of packages alphabetically.