### PR TITLE
Check to make sure `cb` is a function.

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -193,7 +193,7 @@ SyncSettings =
 
       atom.notifications.addSuccess "sync-settings: Your settings were successfully synchronized."
 
-      cb() unless callbackAsync
+      cb?() unless callbackAsync
 
   createClient: ->
     token = atom.config.get 'sync-settings.personalAccessToken'


### PR DESCRIPTION
Fixes #135.

This was the only `cb` call which was not checked.