### PR TITLE
Add option blacklisting when creating a backup.

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -33,13 +33,20 @@ module.exports = {
     type: 'boolean'
     default: true
     order: 8
+  blacklistedKeys:
+    description: 'Comma-seperated list of blacklisted keys'
+    type: 'array'
+    default: []
+    items:
+      type: 'string'
+    order: 9
   extraFiles:
     description: 'Comma-seperated list of files other than Atom\'s default config files in ~/.atom'
     type: 'array'
     default: []
     items:
       type: 'string'
-    order: 9
+    order: 10
   analytics:
     type: 'boolean'
     default: true
@@ -47,20 +54,20 @@ module.exports = {
             Analytics to track what versions and platforms
             are used. Everything is anonymized and no personal information, such as source code,
             is sent. See the README.md for more details."
-    order: 10
+    order: 11
   _analyticsUserId:
     type: 'string'
     default: ""
     description: "Unique identifier for this user for tracking usage analytics"
-    order: 11
+    order: 12
   checkForUpdatedBackup:
     description: 'Check for newer backup on Atom start'
     type: 'boolean'
     default: true
-    order: 12
+    order: 13
   _lastBackupHash:
     type: 'string'
     default: ''
     description: 'Hash of the last backup restored or created'
-    order: 13
+    order: 14
 }

--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -105,7 +105,7 @@ SyncSettings =
   backup: (cb=null) ->
     files = {}
     if atom.config.get('sync-settings.syncSettings')
-      files["settings.json"] = content: JSON.stringify(atom.config.settings, @filterSettings, '\t')
+      files["settings.json"] = content: @getFilteredSettings()
     if atom.config.get('sync-settings.syncPackages')
       files["packages.json"] = content: JSON.stringify(@getPackages(), null, '\t')
     if atom.config.get('sync-settings.syncKeymap')
@@ -208,6 +208,23 @@ SyncSettings =
       type: 'oauth'
       token: token
     github
+
+  getFilteredSettings: ->
+    # _.clone() doesn't deep clone thus we are using JSON parse trick
+    settings = JSON.parse(JSON.stringify(atom.config.settings))
+    for blacklistedKey in atom.config.get('sync-settings.blacklistedKeys') ? []
+      blacklistedKey = blacklistedKey.split(".")
+      @removeProperty(settings, blacklistedKey)
+    return JSON.stringify(settings, @filterSettings, '\t')
+
+  removeProperty: (obj, key) ->
+    lastKey = key.length is 1
+    currentKey = key.shift()
+
+    if not lastKey and _.isObject(obj[currentKey]) and not _.isArray(obj[currentKey])
+      @removeProperty(obj[currentKey], key)
+    else
+      delete obj[currentKey]
 
   filterSettings: (key, value) ->
     return value if key is ""


### PR DESCRIPTION
Initial implementation of blacklisted properties described in #165 

For example to exclude the platform-specific paths
```json
...
"plantuml-preview": {
    "jarLocation": "C:\\bin\\PlantUML\\plantuml.jar",
    "dotLocation": "C:\\bin\\Graphviz\\bin\\dot.exe",
    "zoomToFit": false
}
...
```
you would set `blacklistedKeys` to
```
plantuml-preview.jarLocation, plantuml-preview.dotLocation
```

That would result in
```json
...
"plantuml-preview": {
    "zoomToFit": false
}
...
```

in the backup.

When restoring, local values will be kept!

I'm not 100% familiar with Coffescript, so let me know If something isn't right.