### PR TITLE
trim gist id and personal access token

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -44,21 +44,33 @@ SyncSettings =
 
   serialize: ->
 
+  getGistId: ->
+    gistId = atom.config.get 'sync-settings.gistId'
+    if gistId
+      gistId = gistId.trim()
+    return gistId
+
+  getPersonalAccessToken: ->
+    token = atom.config.get 'sync-settings.personalAccessToken'
+    if token
+      token = token.trim()
+    return token
+
   checkMandatorySettings: ->
     missingSettings = []
-    if not atom.config.get('sync-settings.gistId')
+    if not @getGistId()
       missingSettings.push("Gist ID")
-    if not atom.config.get('sync-settings.personalAccessToken')
+    if not @getPersonalAccessToken()
       missingSettings.push("GitHub personal access token")
     if missingSettings.length
       @notifyMissingMandatorySettings(missingSettings)
     return missingSettings.length is 0
 
   checkForUpdate: (cb=null) ->
-    if atom.config.get('sync-settings.gistId')
+    if @getGistId()
       console.debug('checking latest backup...')
       @createClient().gists.get
-        id: atom.config.get 'sync-settings.gistId'
+        id: @getGistId()
       , (err, res) =>
         console.debug(err, res)
         if err
@@ -148,7 +160,7 @@ SyncSettings =
         content: (@fileContent atom.config.configDirPath + "/#{file}") ? "#{cmtstart} #{file} (not found) #{cmtend}"
 
     @createClient().gists.edit
-      id: atom.config.get 'sync-settings.gistId'
+      id: @getGistId()
       description: atom.config.get 'sync-settings.gistDescription'
       files: files
     , (err, res) ->
@@ -164,7 +176,7 @@ SyncSettings =
 
   viewBackup: ->
     Shell = require 'shell'
-    gistId = atom.config.get 'sync-settings.gistId'
+    gistId = @getGistId()
     Shell.openExternal "https://gist.github.com/#{gistId}"
 
   getPackages: ->
@@ -176,7 +188,7 @@ SyncSettings =
 
   restore: (cb=null) ->
     @createClient().gists.get
-      id: atom.config.get 'sync-settings.gistId'
+      id: @getGistId()
     , (err, res) =>
       if err
         console.error "error while retrieving the gist. does it exists?", err
@@ -218,7 +230,7 @@ SyncSettings =
       cb?() unless callbackAsync
 
   createClient: ->
-    token = atom.config.get 'sync-settings.personalAccessToken'
+    token = @getPersonalAccessToken()
     console.debug "Creating GitHubApi client with token = #{token}"
     github = new GitHubApi
       version: '3.0.0'


### PR DESCRIPTION
Until it is possible to prevent whitespace to be inserted into these configuration values this patch makes sure to trim the value to avoid the problem reported in #153. Fixes #153.