### PR TITLE
add a fork command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ View your online backup using the following command:
 Check the latest backup is applied:
 * `sync-settings:check-backup`
 
+You can also fork existing settings from a different GitHub user using the following command:
+* `sync-settings:fork`
+* In the following input field enter the Gist ID to fork
 
 ## Running the tests
 

--- a/lib/fork-gistid-input-view.coffee
+++ b/lib/fork-gistid-input-view.coffee
@@ -1,0 +1,40 @@
+{CompositeDisposable} = require 'atom'
+{$, TextEditorView, View} = require 'atom-space-pen-views'
+
+oldView = null
+
+module.exports =
+  class ForkGistIdInputView extends View
+    @content: ->
+      @div class: 'command-palette', =>
+        @subview 'selectEditor', new TextEditorView(mini: true, placeholderText: 'Gist ID to fork')
+
+    initialize: ->
+      oldView?.destroy()
+      oldView = this
+
+      @disposables = new CompositeDisposable
+      @disposables.add atom.commands.add 'atom-text-editor', 'core:confirm', => @confirm()
+      @disposables.add atom.commands.add 'atom-text-editor', 'core:cancel', => @destroy()
+      @attach()
+
+    destroy: ->
+      @disposables.dispose()
+      @detach()
+
+    attach: ->
+      @panel ?= atom.workspace.addModalPanel(item: this)
+      @panel.show()
+      @selectEditor.focus()
+
+    detach: ->
+      @panel.destroy()
+      super
+
+    confirm: ->
+      gistId = @selectEditor.getText()
+      @callbackInstance.forkGistId(gistId)
+      @destroy()
+
+    setCallbackInstance: (callbackInstance) ->
+      @callbackInstance = callbackInstance

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "analytics-node": "^1.2.2",
+    "atom-space-pen-views": "^2.2.0",
     "emissary": "1.x",
     "github4": "^0.4.0",
     "loophole": "^1.0.0",


### PR DESCRIPTION
After triggering the new `fork` command the user provides the Gist ID from a different GitHub user and this will fork the settings and store the new Gist ID in the configuration.

This is intended to replace #136.