### PR TITLE
reduce blacklisted key

### DIFF
--- a/lib/sync-settings.coffee
+++ b/lib/sync-settings.coffee
@@ -7,7 +7,12 @@ ForkGistIdInputView = null
 
 # constants
 DESCRIPTION = 'Atom configuration storage operated by http://atom.io/packages/sync-settings'
-REMOVE_KEYS = ["sync-settings"]
+REMOVE_KEYS = [
+  'sync-settings.gistId',
+  'sync-settings.personalAccessToken',
+  'sync-settings._analyticsUserId',
+  'sync-settings._lastBackupHash',
+]
 
 SyncSettings =
   config: require('./config.coffee')


### PR DESCRIPTION
Since it makes sense to sync some of the settings of this package this patch reduces the list of blacklisted key to the ones which are either security critical or specific to a local instance.