### PR TITLE
Added text to explain the gist permissions you need for your token

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ Synchronize settings, keymaps, user styles, init script, snippets and installed 
 ## Setup
 
 1. Open **Sync Settings** configuration in [Atom Settings](atom://config).
-2. Create a [new personal access token](https://github.com/settings/tokens/new) which has the `gist` scope.
+2. Create a [new personal access token](https://github.com/settings/tokens/new) which has the `gist` scope and be sure to activate permissions: Gist -> create gists.
 3. Copy the access token to **Sync Settings** configuration.
 4. Create a [new gist](https://gist.github.com/) and save it.
 5. Copy the gist id (last part of url after the username) to **Sync Settings** configuration.
 
-Disclaimer: Github Gists are by default **public**. If you don't want other people to easily find your gist (i.e. if you use certain packages, storing auth-tokens, a malicious party could abuse them), you should make sure to **create a secret gist**. 
+Disclaimer: Github Gists are by default **public**. If you don't want other people to easily find your gist (i.e. if you use certain packages, storing auth-tokens, a malicious party could abuse them), you should make sure to **create a secret gist**.
 
 ### Alternative **Sync Settings** configuration using Atom's config.cson
 


### PR DESCRIPTION
Just added a small text because if you don't configure the gist permissions you'll get a security error.